### PR TITLE
Fix `CustomErrorResponses` required for Vue.js in the CloudFront distribution

### DIFF
--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -60,8 +60,8 @@ resources:
           DefaultRootObject: 'index.html'
           CustomErrorResponses:
             - ErrorCode: 403
-              ResponseCode: 404
-              ResponsePagePath: '/error.html'
+              ResponseCode: 200
+              ResponsePagePath: '/index.html'
           Origins:
             - DomainName: !GetAtt S3BucketFrontend.DomainName
               Id: s3origin


### PR DESCRIPTION
Whenever a dynamic route is visited, CloudFormation will now pass that request to `index.html` where the Vue router will handle it. The earlier configuration mistakenly passed the request to a non-existing `error.html` page.