### PR TITLE
fixes 'serverless command not found'

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,20 +10,13 @@ blue_bold='\033[1;34m'
 magenta='\033[0;35m'
 reset='\033[0m'     # reset style
 
-npx -v >&/dev/null
-npx_return_code=$?
-
-serverless -v >&/dev/null
-serverless_return_code=$?
-
-if [ $npx_return_code -eq 0 ]
-then
-	deploy_command="npx serverless deploy $@ --verbose"
-elif [ $serverless_return_code -eq 0 ]
-	deploy_command="serverless deploy $@ --verbose"
-else
-	printf "${red}Serverless is not installed. Please run npm install --save-dev first and try again.${reset}\n"
-	exit 1
+deploy_command="serverless deploy $@ --verbose"
+if command -v npx &> /dev/null; then
+    deploy_command="npx $deploy_command"
+elif ! command -v serverless &> /dev/null; then
+    printf "${red}Serverless is not installed.${reset}\n\n"
+    printf "Please run ${blue_bold}npm install --save-dev${reset} first and try again.\n"
+    exit 1
 fi
 
 printf "[1/4] ${blue}Deploying the core stack...${reset}\n"
@@ -34,6 +27,7 @@ printf "[2/4] ${blue}Deploying collectors and analyzers...${reset}\n"
 num_collectors_being_deployed=0
 # Deploy the stacks which have an environment file:
 if [[ -f credentials/analyzers.env ]]; then
+    printf "${blue}Deploying the analyzers...${reset}\n"
     (cd analyzers && $deploy_command)&
 else
     printf "[x] ${red}Unable to deploy the analyzers - environment file does not exist${reset}\n"

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,21 @@ blue_bold='\033[1;34m'
 magenta='\033[0;35m'
 reset='\033[0m'     # reset style
 
-deploy_command="npx serverless deploy $@ --verbose"
+npx -v >&/dev/null
+npx_return_code=$?
+
+serverless -v >&/dev/null
+serverless_return_code=$?
+
+if [ $npx_return_code -eq 0 ]
+then
+	deploy_command="npx serverless deploy $@ --verbose"
+elif [ $serverless_return_code -eq 0 ]
+	deploy_command="serverless deploy $@ --verbose"
+else
+	printf "${red}Serverless is not installed. Please run npm install --save-dev first and try again.${reset}\n"
+	exit 1
+fi
 
 printf "[1/4] ${blue}Deploying the core stack...${reset}\n"
 (cd core && $deploy_command)

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,7 @@ blue_bold='\033[1;34m'
 magenta='\033[0;35m'
 reset='\033[0m'     # reset style
 
-deploy_command="serverless deploy $@ --verbose"
+deploy_command="npx serverless deploy $@ --verbose"
 
 printf "[1/4] ${blue}Deploying the core stack...${reset}\n"
 (cd core && $deploy_command)


### PR DESCRIPTION
**Problem:**

During the setup, since we run `npm install --save-dev`, the node modules are installed locally and so we can't run the binaries without their full path.

I got this error while trying to run `deploy.sh`,

```
$ ./deploy.sh 
[1/4] Deploying the core stack...
./deploy.sh: line 16: serverless: command not found
```

**Fix:**

A possible fix to this problem would be to run it with `npx <command>` or alternatively, add `$(npm bin)` to the `PATH` variable.

Since using `npx` seems like a cleaner alternative, I've added a commit that changed `deploy.sh` to include it.
