### PR TITLE
Vulnerabilities API fix

### DIFF
--- a/api/dashboard/vulnerabilities.py
+++ b/api/dashboard/vulnerabilities.py
@@ -33,7 +33,7 @@ def handler(event, context):
             'statusCode': 200,
             'body': json.dumps({
                 'data': {
-                    'vulnerabilities': vuln,
+                    'vulnerabilities': vulns,
                 }
             })
         }


### PR DESCRIPTION
Fixed to return the list of vulnerabilities (`vulns`) instead of the last vulnerability (`vuln`) in [vulnerabilities.py](https://github.com/riskprofiler/CloudFrontier/blob/master/api/dashboard/vulnerabilities.py#L36)