### PR TITLE
Use AWS account ID in the value for `S3BucketFrontend`

### DIFF
--- a/frontend/serverless.yml
+++ b/frontend/serverless.yml
@@ -6,7 +6,7 @@ plugins:
   - serverless-s3-sync
 
 custom:
-  S3BucketFrontend: cloud-frontier-frontend-${opt:stage, 'dev'}
+  S3BucketFrontend: cloud-frontier-frontend-#{AWS::AccountId}-${opt:stage, 'dev'}
 
   s3Sync:
     - bucketName: ${self:custom.S3BucketFrontend}


### PR DESCRIPTION
Use AWS account ID in the value for `S3BucketFrontend` to prevent conflicts in deployments across various AWS accounts.

Closes #26.